### PR TITLE
WIP: horrible hacks to get the image to build

### DIFF
--- a/elements/hadoop/install.d/40-setup-hadoop
+++ b/elements/hadoop/install.d/40-setup-hadoop
@@ -54,6 +54,9 @@ function install_hadoop_v2 {
         echo "Not injecting Hadoop native libs"
     fi
 
+    # Fake point to old CentOS 6.x location
+    ln -s /usr/lib64/libsasl2.so.3 /usr/lib64/libsasl2.so.2
+
     # Is this causing a NULL pointer exception?
     if false; then
         # The HiBD Hadoop distribution has a dependency on an old version of

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@
 pbr>=1.8 # Apache-2.0
 
 dib-utils # Apache-2.0
-diskimage-builder!=1.6.0,!=1.7.0,!=1.7.1,>=1.1.2 # Apache-2.0
+#diskimage-builder!=1.6.0,!=1.7.0,!=1.7.1,>=1.1.2 # Apache-2.0
+diskimage-builder==2.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ skipsdist = True
 
 [testenv]
 usedevelop = True
-install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt} {opts} {packages}
+install_command = pip install {opts} {packages}
+#install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt} {opts} {packages}
 setenv =
     VIRTUAL_ENV={envdir}
 deps =


### PR DESCRIPTION
This also involved pinning the specific version of CentOS base image:

export BASE_IMAGE_FILE=CentOS-7-x86_64-GenericCloud-1707.qcow2

Without pinning DIB version, hit problems around updating the selinux rules.
Without pinning the above base image, hit problems around the tools parsing
some of the sudoers files using aguers in CentOS 7.4.